### PR TITLE
Making modman and composer compatible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "wirecard/magento-wcs",
+    "license": "GPL-2.0",
+    "type": "magento-module",
+    "description": "Wirecard Checkout Seamless extension for Magento",
+    "homepage": "https://github.com/wirecard/Magento-WCS",
+    "require": {
+        "php": ">=5.3",
+        "magento-hackathon/magento-composer-installer": "*"
+    }
+}

--- a/modman
+++ b/modman
@@ -1,0 +1,13 @@
+app/code/community/Wirecard/CheckoutSeamless                            app/code/community/Wirecard/CheckoutSeamless
+app/code/local/Wirecard/CheckoutSeamless                                app/code/local/Wirecard/CheckoutSeamless
+app/design/adminhtml/default/default/template/wirecard                  app/design/adminhtml/default/default/template/wirecard
+app/design/frontend/base/default/layout/wirecard_checkoutseamless.xml   app/design/frontend/base/default/layout/wirecard_checkoutseamless.xml
+app/design/frontend/base/default/template/wirecard                      app/design/frontend/base/default/template/wirecard
+app/etc/modules/Wirecard_CheckoutSeamless.xml                           app/etc/modules/Wirecard_CheckoutSeamless.xml
+app/locale/de_AT/Wirecard_CheckoutSeamless.csv                          app/locale/de_AT/Wirecard_CheckoutSeamless.csv
+app/locale/de_DE/Wirecard_CheckoutSeamless.csv                          app/locale/de_DE/Wirecard_CheckoutSeamless.csv
+app/locale/en_US/Wirecard_CheckoutSeamless.csv                          app/locale/en_US/Wirecard_CheckoutSeamless.csv
+js/wirecard                                                             js/wirecard
+skin/adminhtml/default/default/images/wirecard                          skin/adminhtml/default/default/images/wirecard
+skin/frontend/base/default/css/wirecard                                 skin/frontend/base/default/css/wirecard
+skin/frontend/base/default/images/wirecard                              skin/frontend/base/default/images/wirecard


### PR DESCRIPTION
## Description

We use composer and modman to deploy our projects, which means that every 3rd party package we include in our projects should be composer and modman compatible. Since we decided to work with the Wirecard Checkout Seamless extension, we want to also make it composer and modman compatible, so that we stick to our usual workflow.

Of course, the reason behind it is that this is de facto a standard nowadays in the Magento community.
## Changes
- Add composer.json file containing the least required data
- Add modman file to link all files from the extension
