### PR TITLE
Fix template mapping for the store return

### DIFF
--- a/app/design/frontend/base/default/layout/wirecard_checkoutseamless.xml
+++ b/app/design/frontend/base/default/layout/wirecard_checkoutseamless.xml
@@ -90,7 +90,7 @@
     <wirecard_checkoutseamless_processing_storereturn>
         <reference name="root">
             <action method="setTemplate">
-                <template>wirecard_checkoutseamless/seamless/storereturn.phtml</template>
+                <template>wirecard/checkoutseamless/seamless/storereturn.phtml</template>
             </action>
         </reference>
     </wirecard_checkoutseamless_processing_storereturn>


### PR DESCRIPTION
Fix the template mapping for the wirecard_checkoutseamless_processing_storereturn layout handle.

This should fix issue https://github.com/wirecard/magento-wcs/issues/5
